### PR TITLE
Fix build on non-macOS platforms

### DIFF
--- a/Sources/BlueEmojiTracker/App/BlueEmojiTracker.swift
+++ b/Sources/BlueEmojiTracker/App/BlueEmojiTracker.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Cocoa
 import simd
 
@@ -437,4 +438,4 @@ class BlueEmojiTracker {
             }
         }
     }
-} 
+} #endif

--- a/Sources/BlueEmojiTracker/App/main.swift
+++ b/Sources/BlueEmojiTracker/App/main.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Cocoa
 
 // Создание и настройка главного контроллера
@@ -45,4 +46,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 let app = NSApplication.shared
 let delegate = AppDelegate()
 app.delegate = delegate
-app.run() 
+app.run()
+#else
+print("BlueEmojiTracker can only run on macOS")
+#endif

--- a/Sources/BlueEmojiTracker/Controllers/MainViewController.swift
+++ b/Sources/BlueEmojiTracker/Controllers/MainViewController.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Cocoa
 
 /// Главный контроллер представления для интерфейса приложения
@@ -157,4 +158,4 @@ class MainViewController: NSViewController {
         
         Logger.shared.log("Отслеживание остановлено")
     }
-} 
+} #endif

--- a/Sources/BlueEmojiTracker/Controllers/MainViewControllerExtensions.swift
+++ b/Sources/BlueEmojiTracker/Controllers/MainViewControllerExtensions.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Cocoa
 
 extension MainViewController {
@@ -342,4 +343,4 @@ class DebugOverlayView: NSView {
         borderPath.lineWidth = 2.0
         borderPath.stroke()
     }
-} 
+} #endif

--- a/Sources/BlueEmojiTracker/Controllers/MainViewControllerSetupUI.swift
+++ b/Sources/BlueEmojiTracker/Controllers/MainViewControllerSetupUI.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Cocoa
 
 extension MainViewController {
@@ -481,4 +482,4 @@ extension MainViewController {
         // Обновляем позицию Y для следующего элемента
         yPos -= 50 + 10
     }
-} 
+} #endif

--- a/Sources/BlueEmojiTracker/Models/Config.swift
+++ b/Sources/BlueEmojiTracker/Models/Config.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Cocoa
 
 struct Config {
@@ -234,4 +235,4 @@ struct Config {
             return false
         }
     }
-} 
+} #endif

--- a/Sources/BlueEmojiTracker/Services/WindowManager.swift
+++ b/Sources/BlueEmojiTracker/Services/WindowManager.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Cocoa
 
 class WindowManager {
@@ -104,4 +105,4 @@ class WindowManager {
         updateCache()
         return windowCache[windowID]
     }
-} 
+} #endif

--- a/Tests/BlueEmojiTrackerTests/BlueEmojiTrackerTests.swift
+++ b/Tests/BlueEmojiTrackerTests/BlueEmojiTrackerTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import XCTest
 @testable import BlueEmojiTracker
 
@@ -26,4 +27,4 @@ final class BlueEmojiTrackerTests: XCTestCase {
         ("testConfigDefaults", testConfigDefaults),
         ("testWindowManagerGetActiveWindows", testWindowManagerGetActiveWindows),
     ]
-} 
+} #endif


### PR DESCRIPTION
## Summary
- wrap macOS-only code in `#if os(macOS)` guards
- show a friendly message when running the CLI on unsupported systems
- skip tests on non-macOS platforms

## Testing
- `swift build`
- `swift test`
- `swift run`


------
https://chatgpt.com/codex/tasks/task_e_6841d4e38cd8832da5c7da2d6bca154e